### PR TITLE
Add OpenOCD configuration

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,4 @@
 [target.thumbv7em-none-eabihf]
-# TODO: remove runner
 runner = 'arm-none-eabi-gdb -q -x openocd.gdb'
 rustflags = [
   "-C", "link-arg=-Tlink.x",

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb -q -x openocd.gdb'
+runner = "arm-none-eabi-gdb -q -tui -x openocd.gdb"
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 **/*.orig
 **/*.rs.bk
 Cargo.lock
-
-openocd.cfg
-openocd.gdb

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/stlink-v2-1.cfg]
+transport select hla_swd
+source [find target/stm32f7x.cfg]
+
+init
+arm semihosting enable
+reset

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -1,0 +1,3 @@
+target remote :3333
+load
+continue


### PR DESCRIPTION
With this configuration, an example can be run on the Nucleo board like this:
```
cargo run --example=blinky --features=rt,stm32f746
```